### PR TITLE
Add method to get private constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
+    - 7.3
+    - 7.4
     - hhvm
 
 env:
@@ -26,10 +24,8 @@ branches:
 matrix:
     fast_finish: true
     include:
-        - php: 7.0
+        - php: 7.1
           env: COVERAGE=true TEST_COMMAND="composer test-ci"
-        - php: 5.3
-          dist: precise
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
     - 7.2
     - 7.3
     - 7.4
-    - hhvm
 
 env:
     global:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "webmozart/assert": "^1.1.0"
     },
     "require-dev": {

--- a/src/NSA.php
+++ b/src/NSA.php
@@ -24,8 +24,10 @@ class NSA
      */
     public static function getConstant($objectOrClass, $constantName)
     {
+        $class = $objectOrClass;
+
         if (!is_string($objectOrClass)) {
-            Assert::object($objectOrClass, 'Can not get a property of a non object. Variable of type "%s" was given.');
+            Assert::object($objectOrClass, 'Can not get a constant of a non object. Variable of type "%s" was given.');
             $class = get_class($objectOrClass);
         }
 

--- a/tests/Fixture/Dog.php
+++ b/tests/Fixture/Dog.php
@@ -4,6 +4,8 @@ namespace Nyholm\NSA\Tests\Fixture;
 
 class Dog extends Animal
 {
+    private const PRIVATE_CONSTANT = 'initConstant';
+
     private $name = 'initName';
 
     protected $owner = 'initOwner';

--- a/tests/Unit/ConstantTest.php
+++ b/tests/Unit/ConstantTest.php
@@ -16,10 +16,16 @@ class ConstantTest extends \PHPUnit_Framework_TestCase
         NSA::getConstant($o, 'INEXISTENT_CONSTANT');
     }
 
-    public function testGetsPrivateConstant()
+    public function testGetsPrivateConstantByObject()
     {
         $o = new Dog();
         $result = NSA::getConstant($o, 'PRIVATE_CONSTANT');
+        $this->assertEquals('initConstant', $result);
+    }
+
+    public function testGetsPrivateConstantByClassName()
+    {
+        $result = NSA::getConstant(Dog::class, 'PRIVATE_CONSTANT');
         $this->assertEquals('initConstant', $result);
     }
 }

--- a/tests/Unit/ConstantTest.php
+++ b/tests/Unit/ConstantTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nyholm\NSA\tests\Unit;
+
+use Nyholm\NSA;
+use Nyholm\NSA\Tests\Fixture\Dog;
+
+class ConstantTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \LogicException
+     */
+    public function testGetConstantNotExist()
+    {
+        $o = new Dog();
+        NSA::getConstant($o, 'INEXISTENT_CONSTANT');
+    }
+
+    public function testGetsPrivateConstant()
+    {
+        $o = new Dog();
+        $result = NSA::getConstant($o, 'PRIVATE_CONSTANT');
+        $this->assertEquals('initConstant', $result);
+    }
+}


### PR DESCRIPTION
This PR adds support to access private constants. Since private constants were introduced in php7.1, it made sense to bump the required php version, making this a breaking change.

This PR also updates the php matrix in travis ci, and removes testing in hhvm, who stopped supporting php https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html