### PR TITLE
fix issue with static properties on abstract classes

### DIFF
--- a/src/NSA.php
+++ b/src/NSA.php
@@ -57,7 +57,9 @@ class NSA
         $reflectionProperty = static::getAccessibleReflectionProperty($objectOrClass, $propertyName);
 
         $object = $objectOrClass;
-        if (is_string($objectOrClass)) {
+        if ($reflectionProperty->isStatic()) {
+            $object = null;
+        } elseif (is_string($objectOrClass)) {
             $object = (new \ReflectionClass($objectOrClass))->newInstanceWithoutConstructor();
         }
 
@@ -80,7 +82,9 @@ class NSA
         $reflectionProperty = static::getAccessibleReflectionProperty($objectOrClass, $propertyName);
 
         $object = $objectOrClass;
-        if (is_string($objectOrClass)) {
+        if ($reflectionProperty->isStatic()) {
+            $object = null;
+        } elseif (is_string($objectOrClass)) {
             $object = (new \ReflectionClass($objectOrClass))->newInstanceWithoutConstructor();
         }
 

--- a/tests/Fixture/AbstractThing.php
+++ b/tests/Fixture/AbstractThing.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Nyholm\NSA\Tests\Fixture;
+
+abstract class AbstractThing
+{
+    private static $count = 'initCount';
+}

--- a/tests/Unit/StaticTest.php
+++ b/tests/Unit/StaticTest.php
@@ -50,11 +50,25 @@ class StaticTest extends TestCase
         $this->assertEquals('initialAge', $result);
     }
 
+    public function testStaticPrivateGetPropertyOnAbstractClass()
+    {
+        $result = NSA::getProperty('Nyholm\NSA\Tests\Fixture\AbstractThing', 'count');
+        $this->assertEquals('initCount', $result);
+    }
+
     public function testStaticPrivateSetProperty()
     {
         $class = 'Nyholm\NSA\Tests\Fixture\Dog';
         NSA::setProperty($class, 'age', 'foobar');
         $result = NSA::getProperty($class, 'age');
+        $this->assertEquals('foobar', $result);
+    }
+
+    public function testStaticPrivateSetPropertyOnAbstractClass()
+    {
+        $class = 'Nyholm\NSA\Tests\Fixture\AbstractThing';
+        NSA::setProperty($class, 'count', 'foobar');
+        $result = NSA::getProperty($class, 'count');
         $this->assertEquals('foobar', $result);
     }
 


### PR DESCRIPTION
Currently you cannot get or set a private static property on an abstract class because the lib try to instantiate an object.